### PR TITLE
"Reason" column optionally added to unnest() call

### DIFF
--- a/R/en_outages_generation_units.R
+++ b/R/en_outages_generation_units.R
@@ -218,7 +218,7 @@ outages_gen_helper_tidy <- function(out_gen_df){
                   resource_psr_type_mrid = dplyr::if_else(is.na(resource_psr_type_mrid), "none", resource_psr_type_mrid),
                   resource_psr_type_name = dplyr::if_else(is.na(resource_psr_type_name), "none", resource_psr_type_name)) %>%
     dplyr::arrange(resource_psr_type, dt_start, dt_end) %>%
-    tidyr::unnest(available_period) %>%
+    tidyr::unnest(base::intersect(x = c("available_period", "Reason"), y = names(out_gen_df))) %>%
     dplyr::mutate(resource_psr_type_capacity = as.integer(resource_psr_type_capacity),
                   quantity = as.numeric(quantity),
                   start = lubridate::ymd_hm(start, tz = "UTC"),
@@ -247,7 +247,7 @@ outages_prod_helper_tidy <- function(out_gen_df){
                   dt_created = createdDateTime) %>%
     dplyr::mutate(revision_number = as.integer(revision_number)) %>%
     dplyr::arrange(resource_psr_type, dt_start, dt_end) %>%
-    tidyr::unnest(available_period) %>%
+    tidyr::unnest(base::intersect(x = c("available_period", "Reason"), y = names(out_gen_df))) %>%
     dplyr::mutate(resource_psr_type_capacity = as.integer(resource_psr_type_capacity),
                   quantity = as.numeric(quantity),
                   start = lubridate::ymd_hm(start, tz = "UTC"),

--- a/R/en_outages_generation_units.R
+++ b/R/en_outages_generation_units.R
@@ -218,7 +218,7 @@ outages_gen_helper_tidy <- function(out_gen_df){
                   resource_psr_type_mrid = dplyr::if_else(is.na(resource_psr_type_mrid), "none", resource_psr_type_mrid),
                   resource_psr_type_name = dplyr::if_else(is.na(resource_psr_type_name), "none", resource_psr_type_name)) %>%
     dplyr::arrange(resource_psr_type, dt_start, dt_end) %>%
-    tidyr::unnest(base::intersect(x = c("available_period", "Reason"), y = names(out_gen_df))) %>%
+    tidyr::unnest( data = ., cols = vapply( ., is.list, TRUE ) %>% which() %>% names() ) %>%
     dplyr::mutate(resource_psr_type_capacity = as.integer(resource_psr_type_capacity),
                   quantity = as.numeric(quantity),
                   start = lubridate::ymd_hm(start, tz = "UTC"),
@@ -247,7 +247,7 @@ outages_prod_helper_tidy <- function(out_gen_df){
                   dt_created = createdDateTime) %>%
     dplyr::mutate(revision_number = as.integer(revision_number)) %>%
     dplyr::arrange(resource_psr_type, dt_start, dt_end) %>%
-    tidyr::unnest(base::intersect(x = c("available_period", "Reason"), y = names(out_gen_df))) %>%
+    tidyr::unnest( data = ., cols = vapply( ., is.list, TRUE ) %>% which() %>% names() ) %>%
     dplyr::mutate(resource_psr_type_capacity = as.integer(resource_psr_type_capacity),
                   quantity = as.numeric(quantity),
                   start = lubridate::ymd_hm(start, tz = "UTC"),

--- a/R/en_outages_generation_units.R
+++ b/R/en_outages_generation_units.R
@@ -219,7 +219,7 @@ outages_gen_helper_tidy <- function(out_gen_df){
                   resource_psr_type_name = dplyr::if_else(is.na(resource_psr_type_name), "none", resource_psr_type_name)) %>%
     dplyr::arrange(resource_psr_type, dt_start, dt_end) %>%
     tidyr::unnest( data = ., cols = vapply( ., is.list, TRUE ) %>% which() %>% names() ) %>%
-    { if( "Reason" %in% names(.) ) tidyr::unite( data = ., col = "Reason", grep( pattern = "^Reason", x = names( . ), value = TRUE ), na.rm = TRUE, sep = "|" ) else . }
+    { if( "Reason" %in% names(.) ) tidyr::unite( data = ., col = "Reason", grep( pattern = "^Reason", x = names( . ), value = TRUE ), na.rm = TRUE, sep = "|" ) else . } %>%
     dplyr::mutate(resource_psr_type_capacity = as.integer(resource_psr_type_capacity),
                   quantity = as.numeric(quantity),
                   start = lubridate::ymd_hm(start, tz = "UTC"),

--- a/R/en_outages_generation_units.R
+++ b/R/en_outages_generation_units.R
@@ -219,6 +219,7 @@ outages_gen_helper_tidy <- function(out_gen_df){
                   resource_psr_type_name = dplyr::if_else(is.na(resource_psr_type_name), "none", resource_psr_type_name)) %>%
     dplyr::arrange(resource_psr_type, dt_start, dt_end) %>%
     tidyr::unnest( data = ., cols = vapply( ., is.list, TRUE ) %>% which() %>% names() ) %>%
+    { if( "Reason" %in% names(.) ) tidyr::unite( data = ., col = "Reason", grep( pattern = "^Reason", x = names( . ), value = TRUE ), na.rm = TRUE, sep = "|" ) else . }
     dplyr::mutate(resource_psr_type_capacity = as.integer(resource_psr_type_capacity),
                   quantity = as.numeric(quantity),
                   start = lubridate::ymd_hm(start, tz = "UTC"),
@@ -248,6 +249,7 @@ outages_prod_helper_tidy <- function(out_gen_df){
     dplyr::mutate(revision_number = as.integer(revision_number)) %>%
     dplyr::arrange(resource_psr_type, dt_start, dt_end) %>%
     tidyr::unnest( data = ., cols = vapply( ., is.list, TRUE ) %>% which() %>% names() ) %>%
+    { if( "Reason" %in% names(.) ) tidyr::unite( data = ., col = "Reason", grep( pattern = "^Reason", x = names( . ), value = TRUE ), na.rm = TRUE, sep = "|" ) else . } %>%
     dplyr::mutate(resource_psr_type_capacity = as.integer(resource_psr_type_capacity),
                   quantity = as.numeric(quantity),
                   start = lubridate::ymd_hm(start, tz = "UTC"),


### PR DESCRIPTION
in outages_gen_helper_tidy() & outages_prod_helper_tidy()
The "Reason" column arrives as list which cannot be consumed by en_outages() function call without these changes.